### PR TITLE
introduced a MockPaillierContext.

### DIFF
--- a/src/main/java/com/n1analytics/paillier/MockPaillierContext.java
+++ b/src/main/java/com/n1analytics/paillier/MockPaillierContext.java
@@ -53,7 +53,11 @@ public class MockPaillierContext extends PaillierContext {
       exponent2 = exponent1;
     } // else do nothing
     BigInteger result = value1.add(value2);
-    if(result.compareTo(modulus) != -1){
+    //this tests for overflows
+    BigInteger posValue1 = (isSigned() && value1.compareTo(getMinEncoded())>=0)? value1.subtract(this.getPublicKey().modulus) : value1;
+    BigInteger posValue2 = (isSigned() && value2.compareTo(getMinEncoded())>=0)? value2.subtract(this.getPublicKey().modulus) : value2;
+
+    if(posValue1.add(posValue2).compareTo(modulus) != -1){
       logger.warning("Overflow occured in add()");
     }
     return new EncryptedNumber(this, result.mod(modulus), exponent1);
@@ -84,7 +88,11 @@ public class MockPaillierContext extends PaillierContext {
     final BigInteger value1 = operand1.ciphertext;
     final BigInteger value2 = operand2.getValue();
     final BigInteger result = value1.multiply(value2);
-    if(result.compareTo(getPublicKey().getModulus()) != -1){
+    
+    //this tests for overflows
+    BigInteger posValue1 = (isSigned() && value1.compareTo(getMinEncoded())>=0)? value1.subtract(this.getPublicKey().modulus) : value1;
+    BigInteger posValue2 = (isSigned() && value2.compareTo(getMinEncoded())>=0)? value2.subtract(this.getPublicKey().modulus) : value2;
+    if(posValue1.multiply(posValue2).compareTo(getPublicKey().getModulus()) != -1){
       logger.warning("Overflow occured in multiply()");
     }
     final int exponent = operand1.getExponent() + operand2.getExponent();

--- a/src/main/java/com/n1analytics/paillier/MockPaillierContext.java
+++ b/src/main/java/com/n1analytics/paillier/MockPaillierContext.java
@@ -1,0 +1,114 @@
+package com.n1analytics.paillier;
+
+import java.math.BigInteger;
+import java.util.logging.Logger;
+
+/**
+ * This is a mock version of the PaillierContext.
+ * 
+ * !!! THIS IS FOR DEBUGGING PURPOSES ONLY !!!
+ * 
+ * It emulates the arithmetic of the PaillierContext without the expensive encryption operations.
+ * Thus, no values get actually encrypted. Everything is in the clear!
+ * 
+ * @author whenecka
+ *
+ */
+public class MockPaillierContext extends PaillierContext {
+
+  private static Logger logger = Logger.getLogger("com.n1analytics.paillier");
+  
+  public MockPaillierContext(PaillierPublicKey publicKey, boolean signed, int precision) {
+    super(publicKey, signed, precision);
+    logger.warning("You are using the MockPaillierContext. Are you sure? This is NOT secure/private!");
+  }
+
+  public EncryptedNumber obfuscate(EncryptedNumber encrypted) {
+    //we skip this
+    return encrypted;
+  }
+  
+  public EncryptedNumber encrypt(EncodedNumber encoded) {
+    //we don't actually encrypt. 
+    checkSameContext(encoded);
+    final BigInteger modulus = getPublicKey().getModulus();
+    final BigInteger value = encoded.getValue();
+    return new EncryptedNumber(this, value.mod(modulus), encoded.getExponent());
+  }
+  
+  public EncryptedNumber add(EncryptedNumber operand1, EncryptedNumber operand2)
+      throws PaillierContextMismatchException {
+    checkSameContext(operand1);
+    checkSameContext(operand2);
+    final BigInteger modulus = getPublicKey().getModulus();
+    BigInteger value1 = operand1.ciphertext;
+    BigInteger value2 = operand2.ciphertext;
+    int exponent1 = operand1.getExponent();
+    int exponent2 = operand2.getExponent();
+    if (exponent1 > exponent2) {
+      value1 = value1.multiply(BigInteger.ONE.shiftLeft(exponent1 - exponent2)).mod(modulus);
+      exponent1 = exponent2;
+    } else if (exponent1 < exponent2) {
+      value2 = value2.multiply(BigInteger.ONE.shiftLeft(exponent2 - exponent1)).mod(modulus);
+      exponent2 = exponent1;
+    } // else do nothing
+    BigInteger result = value1.add(value2);
+    if(result.compareTo(modulus) != -1){
+      logger.warning("Overflow occured in add()");
+    }
+    return new EncryptedNumber(this, result.mod(modulus), exponent1);
+  }
+  
+  public EncryptedNumber additiveInverse(EncryptedNumber operand1) throws PaillierContextMismatchException {
+    checkSameContext(operand1);
+    return new EncryptedNumber(operand1.getContext(),
+        getPublicKey().modulus.subtract(operand1.ciphertext),
+        operand1.getExponent());
+  }
+
+  public EncodedNumber additiveInverse(EncodedNumber operand1) throws PaillierContextMismatchException {
+    checkSameContext(operand1);
+    if (operand1.getValue().signum() == 0) {
+      return operand1;
+    }
+    final BigInteger modulus = getPublicKey().getModulus();
+    final BigInteger value1 = operand1.getValue();
+    final BigInteger result = modulus.subtract(value1);
+    return new EncodedNumber(this, result, operand1.getExponent());
+  }
+  
+  public EncryptedNumber multiply(EncryptedNumber operand1, EncodedNumber operand2)
+      throws PaillierContextMismatchException {
+    checkSameContext(operand1);
+    checkSameContext(operand2);
+    final BigInteger value1 = operand1.ciphertext;
+    final BigInteger value2 = operand2.getValue();
+    final BigInteger result = value1.multiply(value2);
+    if(result.compareTo(getPublicKey().getModulus()) != -1){
+      logger.warning("Overflow occured in multiply()");
+    }
+    final int exponent = operand1.getExponent() + operand2.getExponent();
+    return new EncryptedNumber(this, result.mod(getPublicKey().getModulus()), exponent);
+  }
+  
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null || o.getClass() != MockPaillierContext.class) {
+      return false;
+    }
+    MockPaillierContext context = (MockPaillierContext) o;
+    return getPublicKey().equals(context.getPublicKey()) &&
+            isSigned() == context.isSigned() &&
+            getPrecision() == context.getPrecision();
+  }
+
+  public boolean equals(MockPaillierContext o) {
+    return o == this || (o != null &&
+            getPublicKey().equals(o.getPublicKey()) &&
+            isSigned() == o.isSigned() &&
+            getPrecision() == o.getPrecision());
+  }
+}

--- a/src/main/java/com/n1analytics/paillier/PaillierContext.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierContext.java
@@ -51,7 +51,7 @@ import com.n1analytics.paillier.util.HashChain;
  *   </li>
  * </ul>
  */
-public final class PaillierContext {
+public class PaillierContext {
 
   private final PaillierPublicKey publicKey;
   private final boolean signed;

--- a/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
@@ -218,6 +218,10 @@ public final class PaillierPrivateKey {
       throw new PaillierKeyMismatchException();
     }
     
+    if(encrypted.getContext() instanceof MockPaillierContext){
+      return new EncodedNumber(encrypted.getContext(), encrypted.ciphertext, encrypted.getExponent());
+    }
+    
     BigInteger decryptedToP = lFunction(
         encrypted.ciphertext.modPow(p.subtract(BigInteger.ONE), pSquared), p)
         .multiply(hp).mod(p);

--- a/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
@@ -121,6 +121,23 @@ public final class PaillierPublicKey {
   public PaillierContext createSignedContext(int precision) {
     return new PaillierContext(this, true, precision);
   }
+  
+  public MockPaillierContext createMockUnsignedContext() {
+    return new MockPaillierContext(this, false, modulus.bitLength());
+  }
+
+  public MockPaillierContext createMockUnsignedContext(int precision)
+          throws IllegalArgumentException {
+    return new MockPaillierContext(this, false, precision);
+  }
+
+  public MockPaillierContext createMockSignedContext() {
+    return new MockPaillierContext(this, true, modulus.bitLength());
+  }
+
+  public MockPaillierContext createMockSignedContext(int precision) {
+    return new MockPaillierContext(this, true, precision);
+  }
 
   @Override
   public int hashCode() {

--- a/src/test/java/com/n1analytics/paillier/MockPaillierContextTest.java
+++ b/src/test/java/com/n1analytics/paillier/MockPaillierContextTest.java
@@ -1,0 +1,113 @@
+package com.n1analytics.paillier;
+
+import static org.junit.Assert.*;
+
+import java.math.BigInteger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MockPaillierContextTest {
+
+  static PaillierPrivateKey key;
+  static PaillierPublicKey publicKey;
+  static MockPaillierContext mockContext;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    key = PaillierPrivateKey.create(1024);
+    publicKey = key.getPublicKey();
+    mockContext = publicKey.createMockSignedContext();
+  }
+
+  @Test
+  public void testConstructor() throws Exception {
+    PaillierContext context = null;
+
+    try {
+      context = new MockPaillierContext(null, false, 10);
+      fail("Successfully created a context with null public key");
+    } catch (NullPointerException e) {
+    }
+    assertNull(context);
+
+    try {
+      context = new MockPaillierContext(publicKey, false, 0);
+      fail("Successfully created a context with precision less than one");
+    } catch (IllegalArgumentException e) {
+    }
+    assertNull(context);
+
+    try {
+      context = new MockPaillierContext(publicKey, true, 1);
+      fail("Successfully created a context with precision less than one when signed is true");
+    } catch (IllegalArgumentException e) {
+    }
+    assertNull(context);
+
+    try {
+      context = new MockPaillierContext(publicKey, true, 1032);
+      fail("Successfully created a context with precision greater than the public key's modulus bit length");
+    } catch (IllegalArgumentException e) {
+    }
+    assertNull(context);
+
+    context = new MockPaillierContext(publicKey, true, 1024);
+    assertNotNull(context);
+    // Check public key
+    assertNotNull(context.getPublicKey());
+    assertEquals(publicKey, context.getPublicKey());
+    // Check signed
+    assertTrue(context.isSigned());
+    // Check precision
+    assertNotNull(context.getPrecision());
+    assertEquals(1024, context.getPrecision());
+  }
+  
+  @Test
+  public void testObfuscate(){
+    EncryptedNumber n = new EncryptedNumber(mockContext, BigInteger.ONE, 0);
+    EncryptedNumber m = mockContext.obfuscate(n);
+    assertEquals(n.ciphertext, m.ciphertext);
+    assertEquals(n.exponent, m.exponent);
+    assertEquals(n.context, m.context);
+    assertEquals(n.isSafe, m.isSafe);
+  }
+  
+  @Test
+  public void testEncrypt(){
+    EncodedNumber n = mockContext.encode(42.42);
+    EncryptedNumber m = mockContext.encrypt(n);
+    assertEquals(n.value, m.ciphertext);
+    assertEquals(n.exponent,m.exponent);
+  }
+  
+  @Test
+  public void testAdd(){
+    EncodedNumber n = mockContext.encode(42.42e-120);
+    EncodedNumber m = mockContext.encode(123);
+    EncryptedNumber nplusm = mockContext.encrypt(n).add(mockContext.encrypt(m));
+    EncodedNumber nplusm_e = n.add(m);
+    assertEquals(nplusm.ciphertext, nplusm_e.value);
+    assertEquals(nplusm.exponent, nplusm_e.exponent);
+  }
+  
+  @Test
+  public void testAdditiveInverse(){
+    EncodedNumber n = mockContext.encode(123.456);
+    EncodedNumber minusN = mockContext.additiveInverse(n);
+    assertEquals(minusN.decodeDouble(), n.decodeDouble()*-1, 1e-100);
+    EncryptedNumber en = mockContext.encrypt(n);
+    EncryptedNumber minusEN = mockContext.additiveInverse(en);
+    assertEquals(key.decrypt(en.add(minusEN)).decodeDouble(), 0.0, 1e-100);
+  }
+  
+  @Test
+  public void testMultiply(){
+    EncodedNumber n = mockContext.encode(-987.654321);
+    EncodedNumber m = mockContext.encode(462435.80712);
+    EncryptedNumber nm = mockContext.encrypt(n).multiply(m);
+    assertEquals(key.decrypt(nm), n.multiply(m));
+  }
+
+}


### PR DESCRIPTION
It provides exactly the same arithmetic as PaillierContext but without
encryption. It also logs warnings if overflows occur.
This is meant to be a debugging tool for testing. NEVER use this for
production systems. This is NOT secure in any way.