### PR TITLE
raw Paillier functions and visibility change for PaillierPrivateKey constructor

### DIFF
--- a/src/main/java/com/n1analytics/paillier/PaillierContext.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierContext.java
@@ -345,26 +345,15 @@ public class PaillierContext {
 
   public EncryptedNumber obfuscate(EncryptedNumber encrypted) {
     checkSameContext(encrypted);
-    //final BigInteger modulus = publicKey.getModulus();
-    //final BigInteger modulusSquared = publicKey.getModulusSquared();
-    //final BigInteger value = encrypted.ciphertext;
     final BigInteger obfuscated = publicKey.raw_obfuscate(encrypted.ciphertext);
-    //final BigInteger obfuscated = randomPositiveNumber(modulus).modPow(modulus,
-    //                                                                   modulusSquared).multiply(
-    //       value).mod(modulusSquared);
     return new EncryptedNumber(this, obfuscated, encrypted.getExponent(), true);
   }
 
   public EncryptedNumber encrypt(EncodedNumber encoded) {
-
     checkSameContext(encoded);
-    final BigInteger modulus = publicKey.getModulus();
-    final BigInteger modulusSquared = publicKey.getModulusSquared();
     final BigInteger value = encoded.getValue();
-    //the following encryption only works if the generator is chosen to be modulus+1.
-    //Luckily, the PublicKey definition in this library ensures this property. 
-    final BigInteger result = modulus.multiply(value).add(BigInteger.ONE).mod(modulusSquared);
-    return new EncryptedNumber(this, result, encoded.getExponent());
+    final BigInteger ciphertext = publicKey.raw_encrypt_without_obfuscation(value);
+    return new EncryptedNumber(this, ciphertext, encoded.getExponent(), false);
   }
 
   public EncryptedNumber encrypt(Number value) {

--- a/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
@@ -149,7 +149,7 @@ public final class PaillierPrivateKey {
    * @param q
    *          prime q.
    */
-  private PaillierPrivateKey(PaillierPublicKey publicKey, BigInteger p,
+  protected PaillierPrivateKey(PaillierPublicKey publicKey, BigInteger p,
       BigInteger q) {
     if (publicKey == null) {
       throw new IllegalArgumentException("publicKey must not be null");
@@ -221,16 +221,24 @@ public final class PaillierPrivateKey {
     if(encrypted.getContext() instanceof MockPaillierContext){
       return new EncodedNumber(encrypted.getContext(), encrypted.ciphertext, encrypted.getExponent());
     }
-    
+    return new EncodedNumber(encrypted.getContext(), raw_decrypt(encrypted.ciphertext),
+        encrypted.getExponent());
+  }
+  
+  /**
+   * Implementation of the decryption function of the Paillier encryption scheme.
+   * Returns the plain text of a given cipher text.
+   * @param ciphertext to be decrypted.
+   * @return the decrypted plaintext.
+   */
+  public BigInteger raw_decrypt(BigInteger ciphertext){
     BigInteger decryptedToP = lFunction(
-        encrypted.ciphertext.modPow(p.subtract(BigInteger.ONE), pSquared), p)
+        ciphertext.modPow(p.subtract(BigInteger.ONE), pSquared), p)
         .multiply(hp).mod(p);
     BigInteger decryptedToQ = lFunction(
-        encrypted.ciphertext.modPow(q.subtract(BigInteger.ONE), qSquared), q)
+        ciphertext.modPow(q.subtract(BigInteger.ONE), qSquared), q)
         .multiply(hq).mod(q);
-    BigInteger decrypted = crt(decryptedToP, decryptedToQ);
-    return new EncodedNumber(encrypted.getContext(), decrypted,
-        encrypted.getExponent());
+    return crt(decryptedToP, decryptedToQ);
   }
 
   /**

--- a/src/test/java/com/n1analytics/paillier/RawPaillierTest.java
+++ b/src/test/java/com/n1analytics/paillier/RawPaillierTest.java
@@ -1,0 +1,65 @@
+package com.n1analytics.paillier;
+
+import java.math.BigInteger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class RawPaillierTest {
+
+  static PaillierPrivateKey privateKey;
+  static PaillierPublicKey publicKey;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    privateKey = PaillierPrivateKey.create(1024);
+    publicKey = privateKey.getPublicKey();
+  }
+  
+  @Test
+  public void testEncryptionDecryption(){
+    BigInteger plaintext = new BigInteger("42");
+    BigInteger ciphertext = publicKey.raw_encrypt(plaintext);
+    assertNotEquals(plaintext, ciphertext);
+    assertEquals(plaintext, privateKey.raw_decrypt(ciphertext));
+  }
+  
+  @Test
+  public void testAdd(){
+    BigInteger a = new BigInteger("123");
+    BigInteger b = new BigInteger("7654");
+    BigInteger ciphertext = publicKey.raw_add(publicKey.raw_encrypt(a), publicKey.raw_encrypt(b));
+    assertEquals(privateKey.raw_decrypt(ciphertext), a.add(b));
+    //test overflow
+    a = publicKey.modulus;
+    b = BigInteger.ONE;
+    ciphertext = publicKey.raw_add(publicKey.raw_encrypt(a), publicKey.raw_encrypt(b));
+    assertEquals(privateKey.raw_decrypt(ciphertext), BigInteger.ONE);
+  }
+  
+  @Test
+  public void testMul(){
+    BigInteger a = new BigInteger("95831");
+    BigInteger k = BigInteger.ONE;
+    BigInteger ciphertext = publicKey.raw_multiply(publicKey.raw_encrypt(a), k);
+    assertEquals(privateKey.raw_decrypt(ciphertext), a);
+    k = new BigInteger("842");
+    ciphertext = publicKey.raw_multiply(publicKey.raw_encrypt(a), k);
+    assertEquals(privateKey.raw_decrypt(ciphertext), a.multiply(k));
+    a = publicKey.modulus.subtract(BigInteger.ONE);
+    k = new BigInteger("42");
+    ciphertext = publicKey.raw_multiply(publicKey.raw_encrypt(a), k);
+    assertEquals(privateKey.raw_decrypt(ciphertext), a.multiply(k).mod(publicKey.modulus));
+  }
+  
+  @Test
+  public void testObfuscate(){
+    BigInteger a = new BigInteger("123456789");
+    BigInteger ciphertext = publicKey.raw_encrypt(a);
+    BigInteger obuscatedCiphertext = publicKey.raw_obfuscate(ciphertext);
+    assertNotEquals(ciphertext, obuscatedCiphertext);
+    assertEquals(privateKey.raw_decrypt(obuscatedCiphertext), a);
+  }
+  
+}


### PR DESCRIPTION
having access to the raw Paillier functions enables one to write more sophisticated protocols (e.g. multiplication of two encrypted numbers). 
I changed the visibility of the constructor from private to protected to enable serialisation of the PrivateKey.