### PR TITLE
Jnagmp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ publishMavenStyle := true
 
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.0.13",
-  "com.novocode" % "junit-interface" % "0.11" % Test
+  "com.novocode" % "junit-interface" % "0.11" % Test,
+  "com.squareup.jnagmp" % "jnagmp" % "1.0.1"
 )
 
 publishTo := {

--- a/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
@@ -271,12 +271,14 @@ public final class PaillierPrivateKey {
    * @return the decrypted plaintext.
    */
   public BigInteger raw_decrypt(BigInteger ciphertext){
-    BigInteger decryptedToP = lFunction(
-        ciphertext.modPow(p.subtract(BigInteger.ONE), pSquared), p)
-        .multiply(hp).mod(p);
-    BigInteger decryptedToQ = lFunction(
-        ciphertext.modPow(q.subtract(BigInteger.ONE), qSquared), q)
-        .multiply(hq).mod(q);
+    BigInteger decryptedToP = lFunction(BigIntegerUtil.modPow(ciphertext, p.subtract(BigInteger.ONE), pSquared),p).multiply(hp).mod(p);
+    BigInteger decryptedToQ = lFunction(BigIntegerUtil.modPow(ciphertext, q.subtract(BigInteger.ONE), qSquared),q).multiply(hq).mod(q);
+    //BigInteger decryptedToP = lFunction(
+    //    ciphertext.modPow(p.subtract(BigInteger.ONE), pSquared), p)
+    //    .multiply(hp).mod(p);
+    //BigInteger decryptedToQ = lFunction(
+    //   ciphertext.modPow(q.subtract(BigInteger.ONE), qSquared), q)
+    //    .multiply(hq).mod(q);
     return crt(decryptedToP, decryptedToQ);
   }
 
@@ -293,9 +295,10 @@ public final class PaillierPrivateKey {
    * using Chinese-remaindering'.
    */
   private BigInteger hFunction(BigInteger x, BigInteger xSquared) {
-    return lFunction(
-        publicKey.generator.modPow(x.subtract(BigInteger.ONE), xSquared), x)
-        .modInverse(x);
+    return lFunction(BigIntegerUtil.modPow(publicKey.generator, x.subtract(BigInteger.ONE), xSquared),x).modInverse(x);
+    //return lFunction(
+    //    publicKey.generator.modPow(x.subtract(BigInteger.ONE), xSquared), x)
+    //    .modInverse(x);
   }
 
   /**

--- a/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
@@ -273,12 +273,6 @@ public final class PaillierPrivateKey {
   public BigInteger raw_decrypt(BigInteger ciphertext){
     BigInteger decryptedToP = lFunction(BigIntegerUtil.modPow(ciphertext, p.subtract(BigInteger.ONE), pSquared),p).multiply(hp).mod(p);
     BigInteger decryptedToQ = lFunction(BigIntegerUtil.modPow(ciphertext, q.subtract(BigInteger.ONE), qSquared),q).multiply(hq).mod(q);
-    //BigInteger decryptedToP = lFunction(
-    //    ciphertext.modPow(p.subtract(BigInteger.ONE), pSquared), p)
-    //    .multiply(hp).mod(p);
-    //BigInteger decryptedToQ = lFunction(
-    //   ciphertext.modPow(q.subtract(BigInteger.ONE), qSquared), q)
-    //    .multiply(hq).mod(q);
     return crt(decryptedToP, decryptedToQ);
   }
 
@@ -296,9 +290,6 @@ public final class PaillierPrivateKey {
    */
   private BigInteger hFunction(BigInteger x, BigInteger xSquared) {
     return lFunction(BigIntegerUtil.modPow(publicKey.generator, x.subtract(BigInteger.ONE), xSquared),x).modInverse(x);
-    //return lFunction(
-    //    publicKey.generator.modPow(x.subtract(BigInteger.ONE), xSquared), x)
-    //    .modInverse(x);
   }
 
   /**

--- a/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
@@ -15,6 +15,9 @@ package com.n1analytics.paillier;
 
 import java.math.BigInteger;
 
+import com.n1analytics.paillier.util.BigIntegerUtil;
+import com.squareup.jnagmp.Gmp;
+
 import static com.n1analytics.paillier.util.BigIntegerUtil.randomPositiveNumber;
 
 /**
@@ -228,7 +231,9 @@ public final class PaillierPublicKey {
    * @return obfuscated ciphertext.
    */
   public BigInteger raw_obfuscate(BigInteger ciphertext) {
-    return randomPositiveNumber(modulus).modPow(modulus, modulusSquared).multiply(ciphertext).mod(modulusSquared);
+    return BigIntegerUtil.modPow(randomPositiveNumber(modulus), modulus, modulusSquared).multiply(ciphertext).mod(modulusSquared);
+    //return Gmp.modPowSecure(randomPositiveNumber(modulus), modulus, modulusSquared).multiply(ciphertext).mod(modulusSquared);
+    //return randomPositiveNumber(modulus).modPow(modulus, modulusSquared).multiply(ciphertext).mod(modulusSquared);
   }
   
   /**
@@ -251,7 +256,9 @@ public final class PaillierPublicKey {
    * @return product a*b.
    */
   public BigInteger raw_multiply(BigInteger ciphertext, BigInteger plainfactor){
-    return ciphertext.modPow(plainfactor, modulusSquared);
+    return BigIntegerUtil.modPow(ciphertext, plainfactor, modulusSquared);
+    //return Gmp.modPowSecure(ciphertext, plainfactor, modulusSquared);
+    //return ciphertext.modPow(plainfactor, modulusSquared);
   }
 
   @Override

--- a/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
@@ -16,7 +16,6 @@ package com.n1analytics.paillier;
 import java.math.BigInteger;
 
 import com.n1analytics.paillier.util.BigIntegerUtil;
-import com.squareup.jnagmp.Gmp;
 
 import static com.n1analytics.paillier.util.BigIntegerUtil.randomPositiveNumber;
 

--- a/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPublicKey.java
@@ -231,8 +231,6 @@ public final class PaillierPublicKey {
    */
   public BigInteger raw_obfuscate(BigInteger ciphertext) {
     return BigIntegerUtil.modPow(randomPositiveNumber(modulus), modulus, modulusSquared).multiply(ciphertext).mod(modulusSquared);
-    //return Gmp.modPowSecure(randomPositiveNumber(modulus), modulus, modulusSquared).multiply(ciphertext).mod(modulusSquared);
-    //return randomPositiveNumber(modulus).modPow(modulus, modulusSquared).multiply(ciphertext).mod(modulusSquared);
   }
   
   /**
@@ -256,8 +254,6 @@ public final class PaillierPublicKey {
    */
   public BigInteger raw_multiply(BigInteger ciphertext, BigInteger plainfactor){
     return BigIntegerUtil.modPow(ciphertext, plainfactor, modulusSquared);
-    //return Gmp.modPowSecure(ciphertext, plainfactor, modulusSquared);
-    //return ciphertext.modPow(plainfactor, modulusSquared);
   }
 
   @Override


### PR DESCRIPTION
The jnagmp library provides an interface to call the gmp library to compute a modular exponentiation. On my computer, that's about 4 times as fast as native Java (that's a very nice speed-up for obfuscation and multiply). Apart from testing for an installed version of gmp, jnagmp also contains precompiled versions of gmp for linux and mac. If, for whatever reason, jnagmp is unable to load gmp we will fall back to native Java.