### PR TITLE
Felix's reduce exponent trick

### DIFF
--- a/src/main/java/com/n1analytics/paillier/PaillierContext.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierContext.java
@@ -721,8 +721,14 @@ public class PaillierContext {
           throws PaillierContextMismatchException {
     checkSameContext(operand1);
     checkSameContext(operand2);
-    final BigInteger value1 = operand1.ciphertext;
-    final BigInteger value2 = operand2.getValue();
+    BigInteger value1 = operand1.ciphertext;
+    BigInteger value2 = operand2.getValue();
+    BigInteger neg_plain = publicKey.getModulus().subtract(value2);
+    // If the plaintext is large, exponentiate using its negative instead.
+    if (neg_plain.compareTo(encoding.getMaxEncoded()) <= 0) {
+        value1 = BigIntegerUtil.modInverse(value1, publicKey.getModulusSquared());
+        value2 = neg_plain;
+    }
     final BigInteger result = publicKey.raw_multiply(value1, value2);
     final int exponent = operand1.getExponent() + operand2.getExponent();
     return new EncryptedNumber(this, result, exponent, operand1.isSafe);

--- a/src/main/java/com/n1analytics/paillier/util/BigIntegerUtil.java
+++ b/src/main/java/com/n1analytics/paillier/util/BigIntegerUtil.java
@@ -89,7 +89,7 @@ public class BigIntegerUtil {
   }
 
   /**
-   * Computes the multiplicitive inverse of `a` in the integers, modular `b`.
+   * Computes the multiplicitive inverse of `a` in the integers, modulo `b`.
    *
    * @param a the number to invert
    * @param b the modulus
@@ -100,7 +100,7 @@ public class BigIntegerUtil {
     if(USE_GMP){
       return Gmp.modInverse(a, b);
     } else {
-    return a.modInverse(b);
+      return a.modInverse(b);
     }
   }
 


### PR DESCRIPTION
Passes all tests.

Initial benchmarks suggest that the `inner` method now takes about 60% of runtime instead of ~90%.